### PR TITLE
Feature weight sharing api

### DIFF
--- a/src/core/dev_api/openvino/core/weight_sharing_util.hpp
+++ b/src/core/dev_api/openvino/core/weight_sharing_util.hpp
@@ -1,0 +1,200 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <unordered_map>
+#include <variant>
+
+#include "openvino/core/core_visibility.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+namespace ov {
+class MappedMemory;
+class AlignedBuffer;
+class Model;
+
+namespace op::v0 {
+class Constant;
+}
+}  // namespace ov
+
+namespace ov::weight_sharing {
+using DataID = uint64_t;
+
+/** @brief Defined invalid ID for weight source */
+inline constexpr DataID invalid_source_id = 0;
+/** @brief Defined invalid ID for constant */
+inline constexpr DataID invalid_constant_id = invalid_source_id;
+
+/** @brief Metadata for a weight */
+struct WeightMetaData {
+    size_t m_offset;
+    size_t m_size;
+    ov::element::Type m_type;
+};
+
+/** @brief Metadata for the origin of a weight */
+struct WeightOriginMetaData {
+    DataID m_id;
+    size_t m_offset;
+    size_t m_size;
+    ov::element::Type m_type;
+};
+
+/** @brief Variant type for weight buffer shared pointer*/
+using WeightBuffer = std::shared_ptr<ov::AlignedBuffer>;
+/** @brief Variant type for weight buffer observer*/
+using WeakWeightBuffer = std::weak_ptr<ov::AlignedBuffer>;
+
+/** @brief Map [key: Constant ID, value: WeightMetaData] of constant meta data for single container. */
+using WeightMetaMap = std::unordered_map<DataID, WeightMetaData>;
+/** @brief Map [key: Source ID, value: WeightMetaMap] of constant metadata for constant sources. */
+using WeightRegistry = std::unordered_map<DataID, WeightMetaMap>;
+/** @brief Map [key: Source ID, value: WeakWeightBuffer] of pointers to constant sources. */
+using WeightSourceRegistry = std::unordered_map<DataID, WeakWeightBuffer>;
+/** @brief Map [key: Blob ID, value: blob name] of blobs to model name/tag */
+using BlobMap = std::unordered_map<DataID, std::string>;
+
+/** @brief Shared context for weight and constant management */
+struct Context {
+    WeightRegistry m_weight_registry;        //!< Weight metadata stored in cache for weight sources.
+    WeightSourceRegistry m_cache_sources;    //!< Weight sources stored in cache.
+    WeightSourceRegistry m_runtime_sources;  //!< Weight sources available in runtime, not stored in cache.
+};
+
+/** @brief Extension iface for classes which manage shared context */
+struct OPENVINO_API Extension {
+    /** @brief Get the constant source id for constant node.
+     *
+     * @param constant Constant node to get source id for.
+     * @return Return  Id or INVALID_CONSTANT_ID if not found.
+     */
+    static DataID get_constant_source_id(const ov::op::v0::Constant& constant);
+
+    /** @brief Get the constant id for constant node.
+     *
+     * @param constant Constant node to get id for.
+     * @return Return Id or INVALID_CONSTANT_ID if not found.
+     */
+    static DataID get_constant_id(const ov::op::v0::Constant& constant);
+
+    /** @brief Get the constant origin metadata for constant node.
+     *
+     * @param constant Constant node to get origin metadata for.
+     * @return Return optional with ConstantOriginMetaData if found, std::nullopt otherwise.
+     */
+    static std::optional<WeightOriginMetaData> get_constant_origin(const ov::op::v0::Constant& constant);
+
+    /** @brief Get the constant source buffer for constant node.
+     *
+     * @param constant Constant node to get source buffer for.
+     * @return Return shared pointer to AlignedBuffer if found, nullptr otherwise.
+     */
+    static std::shared_ptr<ov::AlignedBuffer> get_constant_source_buffer(const ov::op::v0::Constant& constant);
+
+    /**
+     * @brief Set constant metadata in weight registry for given constant node.
+     *
+     * @param weight_registry Weight registry to set metadata in.
+     * @param constant Constant node to set metadata for.
+     * @return Return true if metadata was set successfully, false otherwise.
+     */
+    static bool set_constant_in_weight_registry(WeightRegistry& weight_registry, const ov::op::v0::Constant& constant);
+
+    /** @brief Gets the weight sources for a given model.
+     *
+     * @param model Model to get weight sources for.
+     * @return Return map of weight sources.
+     */
+    static WeightSourceRegistry get_weight_sources(const Model& model);
+
+    /** @brief Gets the map where Source ID and Data ID are keys to identify weight meta data.
+     *
+     * @param model Model to get weight registry for.
+     * @return Return map of weight metadata.
+     */
+    static WeightRegistry get_weight_registry(const Model& model);
+};
+
+/** @brief Get the source buffer for a given source id.
+ *
+ * @param shared_context Shared context to get source buffer from.
+ * @param source_id Source id to get buffer for.
+ * @return Return shared pointer to AlignedBuffer if found, nullptr otherwise.
+ */
+OPENVINO_API std::shared_ptr<ov::AlignedBuffer> get_source_buffer(const Context& shared_context,
+                                                                  const DataID source_id);
+
+/** @brief Get the buffer for a given source id and constant id.
+ *
+ * The returned buffer is ready to use for Constant node creation.
+ *
+ * @param shared_context Shared context to get buffer from.
+ * @param source_id Source id to get buffer for.
+ * @param constant_id Constant id to get buffer for.
+ * @return Return shared pointer to AlignedBuffer if found, nullptr otherwise.
+ */
+OPENVINO_API std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
+                                                           const DataID source_id,
+                                                           const DataID constant_id);
+
+/** @brief Get the buffer for a given source buffer (provide source id as hint) and constant id.
+ *
+ * The returned buffer is ready to use for Constant node creation.
+ *
+ * @param shared_context Shared context to get buffer from.
+ * @param source_buffer Source buffer to restore constant buffer to get buffer from.
+ * @param constant_id Constant id to get buffer for.
+ * @return Return shared pointer to AlignedBuffer if found, nullptr otherwise.
+ * @{
+ */
+OPENVINO_API std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
+                                                           const std::shared_ptr<ov::AlignedBuffer>& source_buffer,
+                                                           const DataID constant_id);
+
+OPENVINO_API std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
+                                                           const std::shared_ptr<ov::MappedMemory>& source_buffer,
+                                                           const DataID constant_id);
+/** @} */
+
+/** @brief Set the constant's buffer in context for sharing.
+ *
+ * @param shared_context Shared context to set constant buffer in.
+ * @param constant Constant node to set buffer for.
+ * @return Return true if buffer was set successfully, false otherwise.
+ */
+OPENVINO_API bool set_constant(Context& shared_context, const ov::op::v0::Constant& constant);
+
+/** @brief Set the weight source in context for sharing.
+ *
+ * @param shared_context Shared context to set weight source in.
+ * @param source_buffer Weight buffer to set as source.
+ * @return Return true if source was set successfully, false otherwise.
+ */
+OPENVINO_API bool set_weight_source(Context& shared_context, const WeightBuffer& source_buffer);
+
+/**
+ * @brief Set the weight source object for a given constant node.
+ *
+ * @param shared_context Shared context to set weight source in.
+ * @param constant Constant node to extract source buffer and set as weight source.
+ * @return Return true if source was set successfully, false otherwise.
+ */
+OPENVINO_API bool set_weight_source(Context& shared_context, const ov::op::v0::Constant& constant);
+
+/** @brief Set the weight source in runtime source map of context for sharing.
+ *
+ * @param shared_context Shared context to set weight source in.
+ * @param source_buffer Weight buffer to set as source.
+ * @return Return true if source was set successfully, false otherwise.
+ */
+OPENVINO_API bool set_runtime_weight_source(Context& shared_context, const WeightBuffer& source_buffer);
+}  // namespace ov::weight_sharing
+
+namespace ov {
+namespace wsh = ov::weight_sharing;
+}

--- a/src/core/dev_api/openvino/core/weight_sharing_util.hpp
+++ b/src/core/dev_api/openvino/core/weight_sharing_util.hpp
@@ -7,7 +7,6 @@
 #include <filesystem>
 #include <optional>
 #include <unordered_map>
-#include <variant>
 
 #include "openvino/core/core_visibility.hpp"
 #include "openvino/core/type/element_type.hpp"
@@ -45,17 +44,23 @@ struct WeightOriginMetaData {
     ov::element::Type m_type;
 };
 
-/** @brief Variant type for weight buffer shared pointer*/
+/** @brief Type for weight buffer shared pointer*/
 using WeightBuffer = std::shared_ptr<ov::AlignedBuffer>;
-/** @brief Variant type for weight buffer observer*/
+/** @brief Type for weight buffer observer*/
 using WeakWeightBuffer = std::weak_ptr<ov::AlignedBuffer>;
+
+/** @brief Structure representing a weight source */
+struct WeightSource {
+    std::string m_device;
+    WeakWeightBuffer m_weights;
+};
 
 /** @brief Map [key: Constant ID, value: WeightMetaData] of constant meta data for single container. */
 using WeightMetaMap = std::unordered_map<DataID, WeightMetaData>;
 /** @brief Map [key: Source ID, value: WeightMetaMap] of constant metadata for constant sources. */
 using WeightRegistry = std::unordered_map<DataID, WeightMetaMap>;
-/** @brief Map [key: Source ID, value: WeakWeightBuffer] of pointers to constant sources. */
-using WeightSourceRegistry = std::unordered_map<DataID, WeakWeightBuffer>;
+/** @brief Map [key: Source ID, value: WeightSource] of pointers to constant sources. */
+using WeightSourceRegistry = std::unordered_map<DataID, WeightSource>;
 /** @brief Map [key: Blob ID, value: blob name] of blobs to model name/tag */
 using BlobMap = std::unordered_map<DataID, std::string>;
 

--- a/src/core/dev_api/openvino/core/weight_sharing_util.hpp
+++ b/src/core/dev_api/openvino/core/weight_sharing_util.hpp
@@ -31,17 +31,17 @@ inline constexpr DataID invalid_constant_id = invalid_source_id;
 
 /** @brief Metadata for a weight */
 struct WeightMetaData {
-    size_t m_offset;
-    size_t m_size;
-    ov::element::Type m_type;
+    size_t m_offset;           //!< weight data bytes offset in source buffer.
+    size_t m_size;             //!< weight data size in bytes
+    ov::element::Type m_type;  //!< weight data precisoin.
 };
 
-/** @brief Metadata for the origin of a weight */
+/** @brief Metadata for the origin properties of weight to restore it from the original source. */
 struct WeightOriginMetaData {
-    DataID m_id;
-    size_t m_offset;
-    size_t m_size;
-    ov::element::Type m_type;
+    DataID m_id;               //!< weight id to identify weight in source.
+    size_t m_offset;           //!< weight data bytes offset in source buffer.
+    size_t m_size;             //!< weight data size in bytes
+    ov::element::Type m_type;  //!< weight data precisoin.
 };
 
 /** @brief Type for weight buffer shared pointer*/

--- a/src/core/dev_api/openvino/runtime/aligned_buffer.hpp
+++ b/src/core/dev_api/openvino/runtime/aligned_buffer.hpp
@@ -10,21 +10,20 @@
 #include "openvino/core/core_visibility.hpp"
 
 namespace ov {
-/// \brief Allocates a block of memory on the specified alignment. The actual size of the
-/// allocated memory is larger than the requested size by the alignment, so allocating 1
-/// byte
-/// on 64 byte alignment will allocate 65 bytes.
 
 class AlignedBuffer;
-
 class OPENVINO_API IBufferDescriptor {
 public:
     virtual size_t get_id() const = 0;
     virtual size_t get_offset() const = 0;
     virtual std::shared_ptr<ov::AlignedBuffer> get_source_buffer() const = 0;
-    virtual ~IBufferDescriptor() = default;
+    virtual ~IBufferDescriptor();
 };
 
+/// \brief Allocates a block of memory on the specified alignment. The actual size of the
+/// allocated memory is larger than the requested size by the alignment, so allocating 1
+/// byte
+/// on 64 byte alignment will allocate 65 bytes.
 class OPENVINO_API AlignedBuffer {
 public:
     // Allocator objects and the allocation interfaces are owned by the

--- a/src/core/include/openvino/op/constant.hpp
+++ b/src/core/include/openvino/op/constant.hpp
@@ -20,6 +20,10 @@ namespace ov {
 
 class AlignedBuffer;
 
+namespace weight_sharing {
+struct Extension;
+}
+
 namespace op {
 namespace v0 {
 /// \brief Class for constants.
@@ -388,6 +392,8 @@ private:
     mutable std::atomic_bool m_all_elements_bitwise_identical{false};
     mutable std::atomic_bool m_all_elements_bitwise_identical_checked{false};
     bool m_alloc_buffer_on_visit_attributes{true};
+
+    friend struct ov::weight_sharing::Extension;
 };
 
 template <>

--- a/src/core/src/runtime/aligned_buffer.cpp
+++ b/src/core/src/runtime/aligned_buffer.cpp
@@ -10,6 +10,8 @@
 #include "openvino/core/memory_util.hpp"
 
 namespace ov {
+IBufferDescriptor::~IBufferDescriptor() = default;
+
 AlignedBuffer::AlignedBuffer() : m_allocated_buffer(nullptr), m_aligned_buffer(nullptr), m_byte_size(0) {}
 
 AlignedBuffer::AlignedBuffer(size_t byte_size, size_t alignment) : m_byte_size(byte_size) {

--- a/src/core/src/weight_sharing_util.cpp
+++ b/src/core/src/weight_sharing_util.cpp
@@ -1,0 +1,179 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/weight_sharing_util.hpp"
+
+#include "openvino/core/model.hpp"
+#include "openvino/core/rt_info/weightless_caching_attributes.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/runtime/aligned_buffer.hpp"
+#include "openvino/runtime/shared_buffer.hpp"
+#include "openvino/util/mmap_object.hpp"
+#include "openvino/util/variant_visitor.hpp"
+
+namespace {
+
+bool set_source_buffer(ov::wsh::WeightSourceRegistry& sources, const ov::wsh::WeightBuffer& buffer) {
+    const auto& desc = buffer ? buffer->get_descriptor() : nullptr;
+    const auto source_id = desc ? desc->get_id() : ov::wsh::invalid_source_id;
+    if (source_id != ov::wsh::invalid_source_id) {
+        sources[source_id] = buffer;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+const ov::wsh::WeightMetaData* get_constant_meta(const ov::wsh::WeightRegistry& constants,
+                                                 ov::wsh::DataID src_id,
+                                                 ov::wsh::DataID id) {
+    if (auto found_map = constants.find(src_id); found_map != constants.end()) {
+        if (auto found_desc = found_map->second.find(id); found_desc != found_map->second.end()) {
+            return &found_desc->second;
+        }
+    }
+    return nullptr;
+};
+}  // namespace
+
+namespace ov::weight_sharing {
+
+bool Extension::set_constant_in_weight_registry(WeightRegistry& weight_registry, const ov::op::v0::Constant& constant) {
+    if (const auto desc = constant.m_data->get_descriptor()) {
+        const auto c_id = Extension::get_constant_id(constant);
+        weight_registry[desc->get_id()][c_id] =
+            WeightMetaData{desc->get_offset(), constant.get_byte_size(), constant.get_element_type()};
+        return true;
+    }
+    return false;
+}
+
+WeightSourceRegistry Extension::get_weight_sources(const Model& model) {
+    WeightSourceRegistry src_map;
+    for (const auto& node : model.get_ops()) {
+        if (const auto const_node = ov::as_type<ov::op::v0::Constant>(node.get())) {
+            if (const auto desc = const_node->m_data->get_descriptor()) {
+                if (auto src_buffer = desc->get_source_buffer()) {
+                    src_map.emplace(desc->get_id(), std::move(src_buffer));
+                }
+            }
+        }
+    }
+    return src_map;
+}
+
+WeightRegistry Extension::get_weight_registry(const Model& model) {
+    WeightRegistry constant_map;
+    for (const auto& node : model.get_ops()) {
+        if (const auto const_node = ov::as_type<ov::op::v0::Constant>(node.get())) {
+            set_constant_in_weight_registry(constant_map, *const_node);
+        }
+    }
+    return constant_map;
+}
+
+DataID Extension::get_constant_source_id(const ov::op::v0::Constant& constant) {
+    const auto desc = constant.m_data->get_descriptor();
+    return desc ? desc->get_id() : invalid_source_id;
+}
+
+DataID Extension::get_constant_id(const ov::op::v0::Constant& constant) {
+    const auto desc = constant.m_data->get_descriptor();
+    return desc ? desc->get_offset() : invalid_constant_id;
+}
+
+std::optional<WeightOriginMetaData> Extension::get_constant_origin(const ov::op::v0::Constant& constant) {
+    if (auto wl_attr = constant.get_rt_info().find(ov::WeightlessCacheAttribute::get_type_info_static());
+        wl_attr != constant.get_rt_info().end()) {
+        const auto& wl = wl_attr->second.as<ov::WeightlessCacheAttribute>();
+        return std::make_optional(
+            WeightOriginMetaData{get_constant_source_id(constant), wl.bin_offset, wl.original_size, wl.original_dtype});
+    } else {
+        return std::nullopt;
+    }
+}
+
+std::shared_ptr<ov::AlignedBuffer> Extension::get_constant_source_buffer(const ov::op::v0::Constant& constant) {
+    const auto desc = constant.m_data->get_descriptor();
+    return desc ? desc->get_source_buffer() : nullptr;
+}
+
+std::shared_ptr<ov::AlignedBuffer> get_source_buffer(const Context& shared_context, const DataID source_id) {
+    const auto& weights = shared_context.m_cache_sources;
+    if (auto weight_it = weights.find(source_id); weight_it != weights.end()) {
+        if (auto source_buffer = weight_it->second.lock()) {
+            return std::make_shared<ov::SharedBuffer<WeightBuffer>>(source_buffer->get_ptr<char>(),
+                                                                    source_buffer->size(),
+                                                                    source_buffer);
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
+                                              const DataID source_id,
+                                              const DataID constant_id) {
+    if (const auto source_it = shared_context.m_cache_sources.find(source_id);
+        source_it != shared_context.m_cache_sources.end()) {
+        if (auto wt_buffer = source_it->second.lock()) {
+            if (auto meta = get_constant_meta(shared_context.m_weight_registry, source_id, constant_id)) {
+                return std::make_shared<ov::SharedBuffer<WeightBuffer>>(wt_buffer->get_ptr<char>() + meta->m_offset,
+                                                                        meta->m_size,
+                                                                        wt_buffer);
+            }
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
+                                              const std::shared_ptr<ov::AlignedBuffer>& source_buffer,
+                                              const DataID constant_id) {
+    if (source_buffer) {
+        const auto& desc = source_buffer->get_descriptor();
+        const auto wt_id = desc ? desc->get_id() : ov::wsh::invalid_source_id;
+        const auto& meta_data = get_constant_meta(shared_context.m_weight_registry, wt_id, constant_id);
+        if (meta_data) {
+            return std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::AlignedBuffer>>>(
+                source_buffer->get_ptr<char>() + meta_data->m_offset,
+                meta_data->m_size,
+                source_buffer);
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
+                                              const std::shared_ptr<ov::MappedMemory>& source_buffer,
+                                              const DataID constant_id) {
+    if (source_buffer) {
+        const auto wt_id = source_buffer ? source_buffer->get_id() : ov::wsh::invalid_source_id;
+        const auto& meta_data = get_constant_meta(shared_context.m_weight_registry, wt_id, constant_id);
+        if (meta_data) {
+            return std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(
+                source_buffer->data() + meta_data->m_offset,
+                meta_data->m_size,
+                source_buffer);
+        }
+    }
+    return nullptr;
+}
+
+bool set_constant(Context& shared_context, const ov::op::v0::Constant& constant) {
+    return Extension::set_constant_in_weight_registry(shared_context.m_weight_registry, constant);
+}
+
+bool set_weight_source(Context& shared_context, const WeightBuffer& source_buffer) {
+    return set_source_buffer(shared_context.m_cache_sources, source_buffer);
+}
+
+bool set_weight_source(Context& shared_context, const ov::op::v0::Constant& constant) {
+    const auto source_buffer = Extension::get_constant_source_buffer(constant);
+    return set_source_buffer(shared_context.m_cache_sources, source_buffer);
+}
+
+bool set_runtime_weight_source(Context& shared_context, const WeightBuffer& source_buffer) {
+    return set_source_buffer(shared_context.m_runtime_sources, source_buffer);
+}
+}  // namespace ov::weight_sharing

--- a/src/core/src/weight_sharing_util.cpp
+++ b/src/core/src/weight_sharing_util.cpp
@@ -103,9 +103,7 @@ std::shared_ptr<ov::AlignedBuffer> get_source_buffer(const Context& shared_conte
     const auto& weights = shared_context.m_cache_sources;
     if (auto weight_it = weights.find(source_id); weight_it != weights.end()) {
         if (auto source_buffer = weight_it->second.m_weights.lock()) {
-            return std::make_shared<ov::SharedBuffer<WeightBuffer>>(source_buffer->get_ptr<char>(),
-                                                                    source_buffer->size(),
-                                                                    source_buffer);
+            return source_buffer;
         }
     }
     return nullptr;
@@ -117,7 +115,7 @@ std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
     if (const auto source_it = shared_context.m_cache_sources.find(source_id);
         source_it != shared_context.m_cache_sources.end()) {
         if (auto wt_buffer = source_it->second.m_weights.lock()) {
-            if (auto meta = get_constant_meta(shared_context.m_weight_registry, source_id, constant_id)) {
+            if (const auto meta = get_constant_meta(shared_context.m_weight_registry, source_id, constant_id)) {
                 return std::make_shared<ov::SharedBuffer<WeightBuffer>>(wt_buffer->get_ptr<char>() + meta->m_offset,
                                                                         meta->m_size,
                                                                         wt_buffer);
@@ -133,8 +131,7 @@ std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
     if (source_buffer) {
         const auto& desc = source_buffer->get_descriptor();
         const auto wt_id = desc ? desc->get_id() : ov::wsh::invalid_source_id;
-        const auto& meta_data = get_constant_meta(shared_context.m_weight_registry, wt_id, constant_id);
-        if (meta_data) {
+        if (const auto meta_data = get_constant_meta(shared_context.m_weight_registry, wt_id, constant_id)) {
             return std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::AlignedBuffer>>>(
                 source_buffer->get_ptr<char>() + meta_data->m_offset,
                 meta_data->m_size,
@@ -148,9 +145,8 @@ std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
                                               const std::shared_ptr<ov::MappedMemory>& source_buffer,
                                               const DataID constant_id) {
     if (source_buffer) {
-        const auto meta_data =
-            get_constant_meta(shared_context.m_weight_registry, source_buffer->get_id(), constant_id);
-        if (meta_data) {
+        if (const auto meta_data =
+                get_constant_meta(shared_context.m_weight_registry, source_buffer->get_id(), constant_id)) {
             return std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(
                 source_buffer->data() + meta_data->m_offset,
                 meta_data->m_size,

--- a/src/core/src/weight_sharing_util.cpp
+++ b/src/core/src/weight_sharing_util.cpp
@@ -18,7 +18,7 @@ bool set_source_buffer(ov::wsh::WeightSourceRegistry& sources, const ov::wsh::We
     const auto& desc = buffer ? buffer->get_descriptor() : nullptr;
     const auto source_id = desc ? desc->get_id() : ov::wsh::invalid_source_id;
     if (source_id != ov::wsh::invalid_source_id) {
-        sources[source_id] = buffer;
+        sources[source_id] = ov::wsh::WeightSource{{}, buffer};
         return true;
     } else {
         return false;
@@ -55,7 +55,7 @@ WeightSourceRegistry Extension::get_weight_sources(const Model& model) {
         if (const auto const_node = ov::as_type<ov::op::v0::Constant>(node.get())) {
             if (const auto desc = const_node->m_data->get_descriptor()) {
                 if (auto src_buffer = desc->get_source_buffer()) {
-                    src_map.emplace(desc->get_id(), std::move(src_buffer));
+                    src_map.emplace(desc->get_id(), WeightSource{{}, src_buffer});
                 }
             }
         }
@@ -102,7 +102,7 @@ std::shared_ptr<ov::AlignedBuffer> Extension::get_constant_source_buffer(const o
 std::shared_ptr<ov::AlignedBuffer> get_source_buffer(const Context& shared_context, const DataID source_id) {
     const auto& weights = shared_context.m_cache_sources;
     if (auto weight_it = weights.find(source_id); weight_it != weights.end()) {
-        if (auto source_buffer = weight_it->second.lock()) {
+        if (auto source_buffer = weight_it->second.m_weights.lock()) {
             return std::make_shared<ov::SharedBuffer<WeightBuffer>>(source_buffer->get_ptr<char>(),
                                                                     source_buffer->size(),
                                                                     source_buffer);
@@ -116,7 +116,7 @@ std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
                                               const DataID constant_id) {
     if (const auto source_it = shared_context.m_cache_sources.find(source_id);
         source_it != shared_context.m_cache_sources.end()) {
-        if (auto wt_buffer = source_it->second.lock()) {
+        if (auto wt_buffer = source_it->second.m_weights.lock()) {
             if (auto meta = get_constant_meta(shared_context.m_weight_registry, source_id, constant_id)) {
                 return std::make_shared<ov::SharedBuffer<WeightBuffer>>(wt_buffer->get_ptr<char>() + meta->m_offset,
                                                                         meta->m_size,
@@ -148,8 +148,8 @@ std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
                                               const std::shared_ptr<ov::MappedMemory>& source_buffer,
                                               const DataID constant_id) {
     if (source_buffer) {
-        const auto wt_id = source_buffer ? source_buffer->get_id() : ov::wsh::invalid_source_id;
-        const auto& meta_data = get_constant_meta(shared_context.m_weight_registry, wt_id, constant_id);
+        const auto meta_data =
+            get_constant_meta(shared_context.m_weight_registry, source_buffer->get_id(), constant_id);
         if (meta_data) {
             return std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(
                 source_buffer->data() + meta_data->m_offset,

--- a/src/core/tests/weight_sharing_util_test.cpp
+++ b/src/core/tests/weight_sharing_util_test.cpp
@@ -1,0 +1,385 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/weight_sharing_util.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/common_utils.hpp"
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/core/rt_info/weightless_caching_attributes.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/runtime/aligned_buffer.hpp"
+#include "openvino/runtime/shared_buffer.hpp"
+#include "openvino/util/file_util.hpp"
+#include "openvino/util/mmap_object.hpp"
+#include "openvino/util/variant_visitor.hpp"
+
+namespace ov::test {
+
+using ov::op::v0::Parameter, ov::op::v0::Constant, ov::op::v1::Add;
+
+class WeightShareExtensionTest : public testing::Test {
+protected:
+    void SetUp() override {
+        ov::util::create_directory_recursive(test_dir);
+    }
+
+    void TearDown() override {
+        if (util::directory_exists(test_dir)) {
+            std::filesystem::remove_all(test_dir);
+        }
+    }
+
+    void store_weights(const std::filesystem::path& path, const void* data, size_t size) {
+        if (std::ofstream out_file(path, std::ios::binary); out_file.is_open()) {
+            out_file.write(reinterpret_cast<const char*>(data), size);
+        } else {
+            FAIL() << "Failed to open file for writing: " << path;
+        }
+    }
+
+    void create_test_weights_file(const std::filesystem::path& path, size_t size = 4000) {
+        auto weights = ov::Tensor(ov::element::f32, Shape{size});
+        std::generate_n(weights.data<float>(), weights.get_size(), [n = 0.0f]() mutable {
+            return n++;
+        });
+        store_weights(path, weights.data(), weights.get_byte_size());
+    }
+
+    std::filesystem::path test_dir = utils::generateTestFilePrefix();
+};
+
+const auto read_mmap_into_aligned_buffer = [](const std::filesystem::path& path) -> std::shared_ptr<ov::AlignedBuffer> {
+    if (auto mmap_obj = ov::load_mmap_object(path)) {
+        return std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(mmap_obj->data(),
+                                                                                     mmap_obj->size(),
+                                                                                     mmap_obj);
+    } else {
+        return nullptr;
+    }
+};
+
+const auto create_test_model = []() {
+    auto weights = ov::Tensor(ov::element::f32, Shape{2, 200});
+    std::generate_n(weights.data<float>(), weights.get_size(), [n = 0.0f]() mutable {
+        return n++;
+    });
+
+    auto param = std::make_shared<Parameter>(ov::element::f32, weights.get_shape());
+    auto add = std::make_shared<Add>(param, std::make_shared<Constant>(weights));
+    return std::make_shared<ov::Model>(add->outputs(), "TestModel");
+};
+
+const auto create_test_model_weights_from_file = [](const std::filesystem::path& weights_path) {
+    auto w_buff = ov::load_mmap_object(weights_path);
+
+    auto w1 =
+        std::make_shared<SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(w_buff->data(), w_buff->size() / 2, w_buff);
+    auto w2 = std::make_shared<SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(w_buff->data() + w_buff->size() / 2,
+                                                                                w_buff->size() / 2,
+                                                                                w_buff);
+
+    auto param = std::make_shared<Parameter>(ov::element::f32, Shape{2, 200});
+    auto add = std::make_shared<Add>(param, std::make_shared<Constant>(element::f32, Shape{1, 200}, w1));
+    add = std::make_shared<Add>(add, std::make_shared<Constant>(element::f32, Shape{1, 200}, w2));
+    return std::make_shared<ov::Model>(add->outputs(), "Test model weight from file");
+};
+
+TEST_F(WeightShareExtensionTest, get_constant_id_no_descriptor) {
+    auto constant = Constant(element::i64, Shape{2, 2}, std::vector<int64_t>{1, 2, 3, 4});
+
+    EXPECT_EQ(weight_sharing::Extension::get_constant_source_id(constant), weight_sharing::invalid_source_id);
+    EXPECT_EQ(weight_sharing::Extension::get_constant_id(constant), weight_sharing::invalid_constant_id);
+}
+
+TEST_F(WeightShareExtensionTest, get_constant_id_with_descriptor) {
+    const auto w_path = test_dir / "weights.bin";
+    create_test_weights_file(w_path);
+    auto w_buffer = ov::load_mmap_object(w_path);
+    auto w1 = std::make_shared<SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(w_buffer->data() + 200,
+                                                                                w_buffer->size() - 200,
+                                                                                w_buffer);
+    auto constant = Constant(element::f32, Shape{200}, w1);
+
+    EXPECT_NE(weight_sharing::Extension::get_constant_source_id(constant), weight_sharing::invalid_source_id);
+    EXPECT_NE(weight_sharing::Extension::get_constant_id(constant), weight_sharing::invalid_constant_id);
+}
+
+TEST_F(WeightShareExtensionTest, get_constant_source_buffer_check_id) {
+    GTEST_SKIP() << "Shared buffer with descriptor must but improved to pass this test";
+    const auto w_path = test_dir / "weights.bin";
+    create_test_weights_file(w_path);
+
+    auto w_buffer = ov::load_mmap_object(w_path);
+    auto w1 = std::make_shared<SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(w_buffer->data() + 200,
+                                                                                w_buffer->size() - 200,
+                                                                                w_buffer);
+    auto constant = Constant(element::f32, Shape{200}, w1);
+
+    const auto src_buffer = weight_sharing::Extension::get_constant_source_buffer(constant);
+    ASSERT_TRUE(src_buffer);
+    const auto src_desc = src_buffer->get_descriptor();
+    ASSERT_TRUE(src_desc);
+    EXPECT_NE(src_desc->get_id(), weight_sharing::invalid_source_id);
+}
+
+TEST_F(WeightShareExtensionTest, get_constant_sources_for_model_with_no_source_tags) {
+    auto model = create_test_model();
+    auto weight_sources = weight_sharing::Extension::get_weight_sources(*model);
+    EXPECT_TRUE(weight_sources.empty());
+}
+
+TEST_F(WeightShareExtensionTest, get_constant_sources_for_model_with_source_id) {
+    const auto weights_path = test_dir / "weights.bin";
+    create_test_weights_file(weights_path);
+
+    auto model = create_test_model_weights_from_file(weights_path);
+    auto weight_sources = weight_sharing::Extension::get_weight_sources(*model);
+    ASSERT_GE(weight_sources.size(), 1);
+
+    const auto& wt_weak_buffer = weight_sources.begin()->second;
+    auto buffer = wt_weak_buffer.lock();
+    ASSERT_TRUE(buffer);
+    EXPECT_EQ(buffer->size(), sizeof(float) * 4000);
+}
+
+TEST_F(WeightShareExtensionTest, make_constant_map_for_model_with_no_source_tags) {
+    auto model = create_test_model();
+    auto constant_map = weight_sharing::Extension::get_weight_registry(*model);
+    EXPECT_TRUE(constant_map.empty());
+}
+
+TEST_F(WeightShareExtensionTest, make_constant_map_model_has_tagged_data_source) {
+    const auto weights_path = test_dir / "weights.bin";
+    create_test_weights_file(weights_path);
+
+    auto model = create_test_model_weights_from_file(weights_path);
+    auto constant_map = weight_sharing::Extension::get_weight_registry(*model);
+    EXPECT_GE(constant_map.size(), 1);
+}
+
+TEST_F(WeightShareExtensionTest, get_constant_origin_desc_no_wl_set) {
+    auto c = Constant(element::f32, Shape{2, 2}, std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f});
+    ASSERT_FALSE(weight_sharing::Extension::get_constant_origin(c).has_value());
+}
+
+TEST_F(WeightShareExtensionTest, set_mapped_weight_buffer) {
+    const auto weights_path = test_dir / "weights.bin";
+    create_test_weights_file(weights_path);
+    weight_sharing::Context shared_ctx;
+
+    auto buffer = read_mmap_into_aligned_buffer(weights_path);
+    ASSERT_TRUE(weight_sharing::set_weight_source(shared_ctx, buffer));
+    EXPECT_EQ(shared_ctx.m_cache_sources.size(), 1);
+    EXPECT_EQ(shared_ctx.m_runtime_sources.size(), 0);
+}
+
+TEST_F(WeightShareExtensionTest, set_mapped_weight_buffer_as_rt_data) {
+    const auto weights_path = test_dir / "weights.bin";
+    create_test_weights_file(weights_path);
+    weight_sharing::Context shared_ctx;
+
+    auto buffer = read_mmap_into_aligned_buffer(weights_path);
+    ASSERT_TRUE(weight_sharing::set_runtime_weight_source(shared_ctx, buffer));
+    EXPECT_EQ(shared_ctx.m_cache_sources.size(), 0);
+    EXPECT_EQ(shared_ctx.m_runtime_sources.size(), 1);
+}
+
+TEST_F(WeightShareExtensionTest, set_aligned_weight_buffer) {
+    weight_sharing::Context shared_ctx;
+    auto buffer = std::make_shared<ov::AlignedBuffer>(4000);
+    auto wt_buffer = std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::AlignedBuffer>>>(
+        buffer->get_ptr<char>(),
+        buffer->size(),
+        buffer,
+        ov::create_base_descriptor(12, 0, buffer));
+
+    ASSERT_TRUE(weight_sharing::set_weight_source(shared_ctx, wt_buffer));
+    EXPECT_EQ(shared_ctx.m_cache_sources.size(), 1);
+    EXPECT_EQ(shared_ctx.m_cache_sources.count(12), 1);
+}
+
+TEST_F(WeightShareExtensionTest, set_null_aligned_weight_buffer) {
+    weight_sharing::Context shared_ctx;
+    std::shared_ptr<ov::AlignedBuffer> buffer = nullptr;
+    ASSERT_FALSE(weight_sharing::set_weight_source(shared_ctx, buffer));
+}
+
+TEST_F(WeightShareExtensionTest, set_aligned_weight_buffer_no_tag) {
+    weight_sharing::Context shared_ctx;
+    auto buffer = std::make_shared<ov::AlignedBuffer>(4000);
+
+    ASSERT_FALSE(weight_sharing::set_weight_source(shared_ctx, buffer));
+}
+
+TEST_F(WeightShareExtensionTest, set_aligned_weight_buffer_invalid_tag) {
+    weight_sharing::Context shared_ctx;
+    auto buffer = std::make_shared<ov::AlignedBuffer>(4000);
+
+    ASSERT_FALSE(weight_sharing::set_weight_source(shared_ctx, buffer));
+}
+
+TEST_F(WeightShareExtensionTest, set_constant_buffer_with_no_id) {
+    weight_sharing::Context shared_ctx;
+
+    auto c = Constant(element::f32, Shape{2, 2}, std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f});
+    auto buffer = std::make_shared<ov::AlignedBuffer>(4000);
+
+    ASSERT_FALSE(weight_sharing::set_constant(shared_ctx, c));
+}
+
+TEST_F(WeightShareExtensionTest, set_constant_buffer_with_id) {
+    weight_sharing::Context shared_ctx;
+
+    auto buffer = std::make_shared<ov::AlignedBuffer>(4000);
+    auto wt_buffer = std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::AlignedBuffer>>>(
+        buffer->get_ptr<char>() + 100,
+        buffer->size(),
+        buffer,
+        ov::create_base_descriptor(12, 0, buffer));
+    auto c = Constant(element::f32, Shape{100}, wt_buffer);
+
+    ASSERT_TRUE(weight_sharing::set_constant(shared_ctx, c));
+    const auto& [const_offset, const_size, const_type] = shared_ctx.m_weight_registry[12][100];
+    EXPECT_EQ(const_offset, 100);
+    EXPECT_EQ(const_size, 4000);
+    EXPECT_EQ(const_type, element::f32);
+}
+
+TEST_F(WeightShareExtensionTest, get_origin_meta_data_from_constant) {
+    auto c = Constant(element::f32, Shape{2, 2}, std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f});
+    c.get_rt_info()[ov::WeightlessCacheAttribute::get_type_info_static()] =
+        ov::WeightlessCacheAttribute{32, 0, element::f64};
+
+    const auto origin_desc = weight_sharing::Extension::get_constant_origin(c);
+
+    ASSERT_TRUE(origin_desc.has_value());
+    EXPECT_EQ(origin_desc->m_id, weight_sharing::invalid_source_id);
+    EXPECT_EQ(origin_desc->m_offset, 0);
+    EXPECT_EQ(origin_desc->m_size, 32);
+    EXPECT_EQ(origin_desc->m_type, element::f64);
+}
+
+TEST_F(WeightShareExtensionTest, get_constant_buffer_for_null_weights) {
+    weight_sharing::Context shared_ctx;
+
+    const auto weights_path = test_dir / "weights.bin";
+    create_test_weights_file(weights_path);
+    auto wt_buffer = read_mmap_into_aligned_buffer(weights_path);
+
+    EXPECT_TRUE(weight_sharing::set_weight_source(shared_ctx, wt_buffer));
+    auto c = Constant(element::f32,
+                      Shape{10},
+                      std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::AlignedBuffer>>>(wt_buffer->get_ptr<char>(),
+                                                                                             4 * 10,
+                                                                                             wt_buffer));
+    weight_sharing::set_constant(shared_ctx, c);
+
+    const auto c_id = wsh::Extension::get_constant_id(c);
+    auto constant_buffer = weight_sharing::get_buffer(shared_ctx, wt_buffer, c_id);
+    ASSERT_TRUE(constant_buffer);
+
+    std::shared_ptr<ov::MappedMemory> wt_null;
+    constant_buffer = weight_sharing::get_buffer(shared_ctx, wt_null, c_id);
+    ASSERT_FALSE(constant_buffer);
+}
+
+TEST_F(WeightShareExtensionTest, rebuild_constant_from_shared_context) {
+    const auto weights_path = test_dir / "weights.bin";
+    create_test_weights_file(weights_path);
+
+    // create shared context with constant map for model
+    uint64_t source_id_a{};
+    const weight_sharing::WeightMetaData const_a_1{0, 200, element::f32};
+    const weight_sharing::WeightMetaData const_a_2{200, 20, element::f32};
+
+    weight_sharing::Context shared_ctx;
+
+    // create model, which has been stored to blob
+    auto [model, ref_data] = [&]() -> std::tuple<std::shared_ptr<ov::Model>, std::vector<float>> {
+        auto w_mmap = read_mmap_into_aligned_buffer(weights_path);
+        source_id_a = w_mmap->get_descriptor()->get_id();
+        // plugin can created shared context for model and store buffer with tag
+        ov::wsh::set_weight_source(shared_ctx, w_mmap);
+        const auto& [c1_offset, c1_size, c1_type] = const_a_1;
+        auto w1 =
+            std::make_shared<SharedBuffer<std::shared_ptr<ov::AlignedBuffer>>>(w_mmap->get_ptr<char>() + c1_offset,
+                                                                               c1_size,
+                                                                               w_mmap);
+
+        const auto& [c2_offset, c2_size, c2_type] = const_a_2;
+        auto w2 =
+            std::make_shared<SharedBuffer<std::shared_ptr<ov::AlignedBuffer>>>(w_mmap->get_ptr<char>() + c2_offset,
+                                                                               c2_size,
+                                                                               w_mmap);
+
+        auto c1 = std::make_shared<Constant>(c1_type, Shape{5, 10}, w1);
+        auto c2 = std::make_shared<Constant>(c2_type, Shape{5, 1}, w2);
+        EXPECT_EQ(weight_sharing::Extension::get_constant_source_id(*c1), source_id_a);
+        EXPECT_EQ(weight_sharing::Extension::get_constant_id(*c1), c1_offset);
+        EXPECT_TRUE(weight_sharing::set_constant(shared_ctx, *c1));
+        EXPECT_TRUE(weight_sharing::set_constant(shared_ctx, *c2));
+
+        auto param = std::make_shared<Parameter>(ov::element::f32, Shape{1, 1});
+        auto add = std::make_shared<Add>(param, c2);
+
+        return std::make_tuple(std::make_shared<ov::Model>(add->outputs(), "Test model weight from file"),
+                               c2->cast_vector<float>());
+    }();
+
+    // plugin build constant from shared context, weight buffer exists in memory
+    {
+        // the constant meta data read from blob (source ID, constant ID, shape)
+        const auto const_src_id_from_blob = source_id_a;
+        const auto const_id_from_blob = 200;
+        const auto shape_from_blob = Shape{5, 1};
+
+        // re-create constant buffer from shared context by IDs
+        auto constant_buffer = weight_sharing::get_buffer(shared_ctx, const_src_id_from_blob, const_id_from_blob);
+        ASSERT_TRUE(constant_buffer);
+        ASSERT_TRUE(constant_buffer->get_descriptor());
+        EXPECT_EQ(constant_buffer->get_descriptor()->get_id(), const_src_id_from_blob);
+
+        const auto& c_type = shared_ctx.m_weight_registry[const_src_id_from_blob][const_id_from_blob].m_type;
+        auto c = std::make_shared<Constant>(c_type, shape_from_blob, constant_buffer);
+
+        EXPECT_EQ(c->cast_vector<float>(), ref_data);
+        EXPECT_EQ(weight_sharing::Extension::get_constant_source_id(*c), const_src_id_from_blob);
+        EXPECT_EQ(weight_sharing::Extension::get_constant_id(*c), const_id_from_blob);
+    }
+    // release model the shared context buffer will be not available
+    model.reset();
+    // plugin build constant from shared context but weight buffer has been released
+    {
+        // the constant meta data read from blob (source ID, constant ID, shape)
+        const auto const_src_id_from_blob = source_id_a;
+        const auto const_id_from_blob = 200;
+        const auto shape_from_blob = Shape{5, 1};
+
+        // get constant source buffer fail as not exists in memory
+        auto weight_buffer = ov::wsh::get_source_buffer(shared_ctx, const_src_id_from_blob);
+        ASSERT_FALSE(weight_buffer);
+        auto constant_buffer = ov::wsh::get_buffer(shared_ctx, const_src_id_from_blob, const_id_from_blob);
+        ASSERT_FALSE(constant_buffer);
+
+        // constant can not be rebuild from shared context by IDs, restore manually
+        const auto& c_type = shared_ctx.m_weight_registry[const_src_id_from_blob][const_id_from_blob].m_type;
+        // restore weight buffer from file
+        auto w_buffer = load_mmap_object(weights_path);
+        ASSERT_TRUE(w_buffer);
+        // recreate constant buffer with weight_buffer as hint
+        constant_buffer = weight_sharing::get_buffer(shared_ctx, w_buffer, const_id_from_blob);
+        ASSERT_TRUE(constant_buffer);
+
+        auto c = std::make_shared<Constant>(c_type, shape_from_blob, constant_buffer);
+        EXPECT_EQ(c->cast_vector<float>(), ref_data);
+        EXPECT_EQ(ov::wsh::Extension::get_constant_source_id(*c), const_src_id_from_blob);
+        EXPECT_EQ(ov::wsh::Extension::get_constant_id(*c), const_id_from_blob);
+    }
+}
+}  // namespace ov::test

--- a/src/core/tests/weight_sharing_util_test.cpp
+++ b/src/core/tests/weight_sharing_util_test.cpp
@@ -143,7 +143,7 @@ TEST_F(WeightShareExtensionTest, get_constant_sources_for_model_with_source_id) 
     ASSERT_GE(weight_sources.size(), 1);
 
     const auto& wt_weak_buffer = weight_sources.begin()->second;
-    auto buffer = wt_weak_buffer.lock();
+    auto buffer = wt_weak_buffer.m_weights.lock();
     ASSERT_TRUE(buffer);
     EXPECT_EQ(buffer->size(), sizeof(float) * 4000);
 }
@@ -242,7 +242,7 @@ TEST_F(WeightShareExtensionTest, set_constant_buffer_with_id) {
         buffer->size(),
         buffer,
         ov::create_base_descriptor(12, 0, buffer));
-    auto c = Constant(element::f32, Shape{100}, wt_buffer);
+    auto c = Constant(element::f32, Shape{1000}, wt_buffer);
 
     ASSERT_TRUE(weight_sharing::set_constant(shared_ctx, c));
     const auto& [const_offset, const_size, const_type] = shared_ctx.m_weight_registry[12][100];


### PR DESCRIPTION
### Details:
Weight sharing developer interface to allow re-created constant buffer from shared context.
Add extension to ov::op::v0::Constant node to extract information about internal buffer
Add extension to ov::Model to get weight sources and weights meta data registry
Add function to simplify access to the shared context

### Tickets:
 - [CVS-180929](https://jira.devtools.intel.com/browse/CVS-180929)
